### PR TITLE
feat: composable implementation of Icon button style

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -2,40 +2,40 @@ import type { Component, JSX } from 'solid-js'
 
 import withDefaults from '../../utils/with-defaults'
 import StyledButton from './StyledButton'
-import StyledIcon from './StyledIcon'
+import * as DefaultStyle from './StyledIcon'
 
 export type ButtonProps = {
   block?: boolean
   variant?: 'default' | 'primary' | 'secondary' | 'ghost'
   type?: 'filled' | 'outlined' | 'text'
-  size?: 'extra-small' | 'small' | 'medium' | 'large' | 'extra-large'
-  iconPosition?: 'before' | 'after'
-  shape?: 'rounded' | 'circle'
   disabled?: boolean
   onClick?: JSX.IntrinsicElements['button']['onClick']
-} & (
-  | // Must specify icon, children or both - but never none of them
-  {
-      icon: JSX.Element
-      children?: never
-    }
-  | { icon?: never; children: any }
-  | { icon: JSX.Element; children: any }
-)
-
-const Button: Component<ButtonProps> = (props) => {
-  const { size, icon, iconPosition, children } = props
-
-  const beforeIcon = iconPosition === 'before' && icon && (
-    <StyledIcon position={children && 'before'} size={size}>
-      {icon}
-    </StyledIcon>
+  /** a function to get css properties */
+  getCSSProps?: (props?: ButtonProps | DefaultStyle.Props) => JSX.CSSProperties
+}
+/** for backward compatibility */
+& DefaultStyle.Props &
+  (
+    | // Must specify icon, children or both - but never none of them
+    {
+        icon: JSX.Element
+        children?: never
+      }
+    | { icon?: never; children: any }
+    | { icon: JSX.Element; children: any }
   )
 
-  const afterIcon = iconPosition === 'after' && icon && (
-    <StyledIcon position={children && 'after'} size={size}>
-      {icon}
-    </StyledIcon>
+const Button: Component<ButtonProps> = (props) => {
+  const { icon, children, getCSSProps = DefaultStyle.getCSSProps } = props
+
+  const cssProps = getCSSProps(props)
+
+  const beforeIcon = props.iconPosition === 'before' && icon && (
+    <span style={{ ...cssProps }}>{icon}</span>
+  )
+
+  const afterIcon = props.iconPosition === 'after' && icon && (
+    <span style={{ ...cssProps }}>{icon}</span>
   )
 
   return (

--- a/src/components/button/StyledIcon.ts
+++ b/src/components/button/StyledIcon.ts
@@ -1,31 +1,37 @@
-import { styled } from 'emotion-solid'
 import tw from 'twin.macro'
 
-import type { ButtonProps } from './Button'
-
-type StyledIconProps = {
-  position?: ButtonProps['iconPosition']
-  size?: ButtonProps['size']
+/** the default style that follows the Launch design philosophy */
+export type Props = {
+  /** icon size */
+  size?: 'extra-small' | 'small' | 'medium' | 'large' | 'extra-large'
+  /** button outer shape */
+  shape?: 'rounded' | 'circle'
+  /** the placement of the icon */
+  iconPosition?: 'before' | 'after'
 }
 
 const baseStyles = tw`flex justify-center items-center`
 
-const positionStyles = ({ position }: StyledIconProps) => [
-  position === 'before' && tw`pr-1.5`,
-  position === 'after' && tw`pl-1.5`,
-]
+const positionStyles = ({ iconPosition }: Props) => {
+  switch (iconPosition) {
+    case 'before': return tw`pr-1.5`
+    case 'after': return tw`pl-1.5`
+    default: return undefined
+  }
+}
 
-const sizeStyles = ({ size }: StyledIconProps) => [
-  size === 'small' && { svg: tw`w-4 h-4` },
-  size === 'medium' && { svg: tw`w-4 h-4` },
-  size === 'large' && { svg: tw`w-6 h-6` },
-  size === 'extra-large' && { svg: tw`w-6 h-6` },
-]
+const sizeStyles = ({ size }: Props) => {
+  switch (size) {
+    case 'small': return { svg: tw`w-4 h-4` }
+    case 'medium': return { svg: tw`w-4 h-4` }
+    case 'large': return { svg: tw`w-6 h-6` }
+    case 'extra-large': return { svg: tw`w-6 h-6` }
+    default: return undefined
+  }
+}
 
-const StyledIcon = styled('span')<StyledIconProps>([
-  baseStyles,
-  positionStyles,
-  sizeStyles,
-])
-
-export default StyledIcon
+export const getCSSProps = (props: Props) => ({
+  ...baseStyles,
+  ...positionStyles(props),
+  ...sizeStyles(props),
+})


### PR DESCRIPTION
Here I just made the style of icons customizable using `getCSSProps` function. 

Side benefit: this also will probably have higher performance because the `tw` macro is called lazily depending on the given configuration (in contrast to calculating all the styles for all the configurations and storing it in an array).